### PR TITLE
integrate breaking changes from shinyDashBoardPlus 2.0.0 (fix #4)

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -3,6 +3,12 @@ title: "NEWS"
 output: html_document
 ---
 
+
+## v0.5.1
+
+* breaking changes in shinyDashboardPlus 2.0.0 integrated
+
+
 ## v0.5.0
 
 * clean up old and unnecessary files 

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -35,33 +35,6 @@ suppressWarnings({
 })
 
 
-sidebar_right = rightSidebar(
-  background = "dark",
-  rightSidebarTabContent(
-    id = 1,
-    icon = "desktop",
-    title = "Tab 1",
-    active = TRUE,
-    sliderInput(
-      "obs", 
-      "Number of observations:",
-      min = 0, max = 1000, value = 500
-    )
-  ),
-  rightSidebarTabContent(
-    id = 2,
-    title = "Tab 2",
-    textInput("caption", "Caption", "Data Summary")
-  ),
-  rightSidebarTabContent(
-    id = 3,
-    title = "Tab 3",
-    icon = "paint-brush",
-    numericInput("obs", "Observations:", 10, min = 1, max = 100)
-  ),
-  title = "Right Sidebar"
-  
-)
 
 
 #### _______________________####
@@ -69,13 +42,13 @@ sidebar_right = rightSidebar(
 
 pkg_version <- paste0("OpenRepGrid.ic v", packageVersion("OpenRepGrid.ic"))
 
-header <- dashboardHeaderPlus(
+header <- dashboardHeader(
   # dropdownMenuOutput("notification_menu"),
   title = tagList(
     span(class = "logo-lg", "OpenRepGrid.ic"), 
     span(class = "logo-sm", "")
-  ),
-  fixed = FALSE 
+  )
+  # fixed = FALSE 
 )
 
 
@@ -473,7 +446,7 @@ body <- dashboardBody(
 #### _______________________####
 #### DASHBOARD ####
 
-ui <- dashboardPagePlus(
+ui <- shinydashboardPlus::dashboardPage(
   title = "OpenRepGrid.ic",
   skin = "red",
   header = header,


### PR DESCRIPTION
The `shinyDashboardPlus` package introduced significant breaking changes with version 2.0.0. This caused the issue. These are fixed now.